### PR TITLE
Context can be more easily configured for signature verification.

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -32,7 +32,12 @@ class Context
             $this->headers = $args['headers'];
         }
 
-        $this->signingKeyId = isset($args['signingKeyId']) ? $args['signingKeyId'] : null;
+        // signingKeyId specifies the key used for signing messages.
+        if (isset($args['signingKeyId'])) {
+            $this->signingKeyId = $args['signingKeyId'];
+        } elseif (isset($args['keys']) && count($args['keys']) === 1) {
+            list($this->signingKeyId) = array_keys($args['keys']); // first key
+        }
     }
 
     public function signer()
@@ -51,10 +56,10 @@ class Context
 
     private function signingKey()
     {
-        if ($this->signingKeyId) {
+        if (isset($this->signingKeyId)) {
             return $this->keyStore()->fetch($this->signingKeyId);
         } else {
-            return $this->keyStore()->onlyKey();
+            throw new Exception('no implicit or specified signing key');
         }
     }
 

--- a/src/KeyStore.php
+++ b/src/KeyStore.php
@@ -22,14 +22,4 @@ class KeyStore
             throw new Exception("Key '$id' not found");
         }
     }
-
-    public function onlyKey()
-    {
-        $count = count($this->keys);
-        if ($count == 1) {
-            return reset($this->keys); // first item
-        } else {
-            throw new Exception("expected 1 key, found $count");
-        }
-    }
 }

--- a/tests/KeyStoreTest.php
+++ b/tests/KeyStoreTest.php
@@ -22,21 +22,4 @@ class KeyStoreTest extends \PHPUnit_Framework_TestCase
         $ks = new KeyStore(array('id' => 'secret'));
         $key = $ks->fetch('nope');
     }
-
-    public function testOnlyKey()
-    {
-        $ks = new KeyStore(array('id' => 'secret'));
-        $key = $ks->onlyKey();
-        $this->assertEquals('id', $key->id);
-        $this->assertEquals('secret', $key->secret);
-    }
-
-    /**
-     * @expectedException HttpSignatures\Exception
-     */
-    public function testOnlyKeyFailsWithMultiple()
-    {
-        $ks = new KeyStore(array('id' => 'secret', 'another' => 'key'));
-        $key = $ks->onlyKey();
-    }
 }


### PR DESCRIPTION
Arguments that are only required for signing messages are now optional.

`KeyStore::onlyKey()` has been removed; Context sets `signingKeyId` instead.

This simplifies the KeyStore interface, and importantly allows it to be implemented with a non-enumerable backend, where keys can be requested by name, but cannot be listed.

Context accepts `keyStore` object as an alternative to `keys` array.
