### PR TITLE
added support in the Verifier for the 'Authorization' header

### DIFF
--- a/src/Verification.php
+++ b/src/Verification.php
@@ -89,21 +89,29 @@ class Verification
 
     private function hasSignatureHeader()
     {
-        return $this->message->headers->has('Signature');
+        return $this->message->headers->has('Signature') || $this->message->headers->has('Authorization');
     }
 
     private function signatureHeader()
     {
-        return $this->fetchHeader('Signature');
+        if ($signature = $this->fetchHeader('Signature', true)) {
+            return $signature;
+        } else if ($authorization = $this->fetchHeader('Authorization', true)) {
+            return substr($authorization, strlen('Signature '));
+        } else {
+            throw new Exception("HTTP message has no Signature or Authorization header");
+        }
     }
 
-    private function fetchHeader($name)
+    private function fetchHeader($name, $silent = false)
     {
         $headers = $this->message->headers;
         if ($headers->has($name)) {
             return $headers->get($name);
-        } else {
+        } else if (!$silent) {
             throw new Exception("HTTP message has no '$name' header");
+        } else {
+            return null;
         }
     }
 }

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -94,24 +94,18 @@ class Verification
 
     private function signatureHeader()
     {
-        if ($signature = $this->fetchHeader('Signature', true)) {
+        if ($signature = $this->fetchHeader('Signature')) {
             return $signature;
-        } else if ($authorization = $this->fetchHeader('Authorization', true)) {
+        } else if ($authorization = $this->fetchHeader('Authorization')) {
             return substr($authorization, strlen('Signature '));
         } else {
             throw new Exception("HTTP message has no Signature or Authorization header");
         }
     }
 
-    private function fetchHeader($name, $silent = false)
+    private function fetchHeader($name)
     {
         $headers = $this->message->headers;
-        if ($headers->has($name)) {
-            return $headers->get($name);
-        } else if (!$silent) {
-            throw new Exception("HTTP message has no '$name' header");
-        } else {
-            return null;
-        }
+        return $headers->has($name) ? $headers->get($name) : null;
     }
 }

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -11,7 +11,14 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
     const DATE = "Fri, 01 Aug 2014 13:44:32 -0700";
     const DATE_DIFFERENT = "Fri, 01 Aug 2014 13:44:33 -0700";
 
+    /**
+     * @var Verifier
+     */
     private $verifier;
+
+    /**
+     * @var Request
+     */
     private $message;
 
     public function setUp()
@@ -39,12 +46,20 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
         $this->message = Request::create('/path?query=123', 'GET');
         $this->message->headers->replace(array(
             "Date" => self::DATE,
-            "Signature" => $signatureHeader,
+            "Signature" => $signatureHeader
         ));
     }
 
     public function testVerifyValidMessage()
     {
+        $this->assertTrue($this->verifier->isValid($this->message));
+    }
+
+    public function testVerifyValidMessageAuthorizationHeader()
+    {
+        $this->message->headers->set('Authorization', "Signature {$this->message->headers->get('Signature')}");
+        $this->message->headers->remove('Signature');
+
         $this->assertTrue($this->verifier->isValid($this->message));
     }
 


### PR DESCRIPTION
I'm not very good at reading specs so I might be wrong, but afaik it should be possible to use the 'Authorization' header without the 'Signature' header...  
At least some libraries in other languages (python for example) don't send the 'Signature' header along, only the 'Authorization' so it would be nice if the Verifier would be able to deal with that!

Even if it's not completely acording to spec (I'm not sure, I get dizzy whenever I open that http://tools.ietf.org/html/draft-cavage-http-signatures-03#section-2.1.3 page) this doesn't break anything and it does add support for the slightly different implentations!