### PR TITLE
Query string ordering fix.

### DIFF
--- a/src/SigningString.php
+++ b/src/SigningString.php
@@ -2,6 +2,8 @@
 
 namespace HttpSignatures;
 
+use HttpSignatures\SymfonyRequestMessage;
+
 class SigningString
 {
     private $headerList;
@@ -10,7 +12,11 @@ class SigningString
     public function __construct($headerList, $message)
     {
         $this->headerList = $headerList;
-        $this->message = $message;
+        if ($message instanceof \Symfony\Component\HttpFoundation\Request) {
+            $this->message = new SymfonyRequestMessage($message);
+        } else {
+            $this->message = $message;
+        }
     }
 
     public function string()

--- a/src/SymfonyRequestMessage.php
+++ b/src/SymfonyRequestMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace HttpSignatures;
+
+class SymfonyRequestMessage
+{
+    private $request;
+    public $headers;
+
+    public function __construct($request)
+    {
+        $this->request = $request;
+        $this->headers = $request->headers;
+    }
+
+    public function getPathInfo()
+    {
+        return $this->request->getPathInfo();
+    }
+
+    public function getQueryString()
+    {
+        // Symfony\Component\HttpFoundation\Request::getQueryString() is not
+        // suitable for HTTP signatures as it mangles the query string.
+        return $this->request->server->get('QUERY_STRING');
+    }
+
+    public function getMethod()
+    {
+        return $this->request->getMethod();
+    }
+}

--- a/tests/SigningStringTest.php
+++ b/tests/SigningStringTest.php
@@ -12,7 +12,7 @@ class SigningStringTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->message = Request::create('/path?query=123', 'GET');
+        $this->message = Request::create('/path?query=123&another=yes', 'GET');
         $this->message->headers->replace(array('date' => 'Mon, 28 Jul 2014 15:39:13 -0700'));
     }
 
@@ -22,7 +22,7 @@ class SigningStringTest extends \PHPUnit_Framework_TestCase
         $ss = new SigningString($headerList, $this->message);
 
         $this->assertEquals(
-            "(request-target): get /path?query=123\ndate: Mon, 28 Jul 2014 15:39:13 -0700",
+            "(request-target): get /path?query=123&another=yes\ndate: Mon, 28 Jul 2014 15:39:13 -0700",
             $ss->string()
         );
     }


### PR DESCRIPTION
Turns out `Symfony\Component\HttpFoundation\Request` `getQueryString()` isn't suitable for generating/verifying signing strings:

> Generates the normalized query string for the Request.
> It builds a normalized query string, where keys/value pairs are alphabetized and have consistent escaping.
— http://api.symfony.com/2.0/Symfony/Component/HttpFoundation/Request.html#method_getQueryString

I'm told by @dhotson that `$request->server->get('QUERY_STRING')` is probably what I want.

- [x] Demonstrate bug with failing test.
- [x] Fix implementation.
- [ ] Squash commits
- [ ] :ship: