### PR TITLE
Add phpDoc to public methods on classes

### DIFF
--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -9,6 +9,11 @@ class Algorithm
         // static class.
     }
 
+    /**
+     * @param string $name
+     * @return HmacAlgorithm
+     * @throws Exception
+     */
     public static function create($name)
     {
         switch ($name) {

--- a/src/Context.php
+++ b/src/Context.php
@@ -4,11 +4,22 @@ namespace HttpSignatures;
 
 class Context
 {
+    /** @var array */
     private $headers;
+
+    /** @var KeyStoreInterface */
     private $keyStore;
+
+    /** @var array */
     private $keys;
+
+    /** @var string */
     private $signingKeyId;
 
+    /**
+     * @param array $args
+     * @throws Exception
+     */
     public function __construct($args)
     {
         if (isset($args['keys']) && isset($args['keyStore'])) {
@@ -38,6 +49,10 @@ class Context
         }
     }
 
+    /**
+     * @return Signer
+     * @throws Exception
+     */
     public function signer()
     {
         return new Signer(
@@ -47,11 +62,19 @@ class Context
         );
     }
 
+    /**
+     * @return Verifier
+     */
     public function verifier()
     {
         return new Verifier($this->keyStore());
     }
 
+    /**
+     * @return Key
+     * @throws Exception
+     * @throws KeyStoreException
+     */
     private function signingKey()
     {
         if (isset($this->signingKeyId)) {
@@ -61,16 +84,26 @@ class Context
         }
     }
 
+    /**
+     * @return HmacAlgorithm
+     * @throws Exception
+     */
     private function algorithm()
     {
         return Algorithm::create($this->algorithmName);
     }
 
+    /**
+     * @return HeaderList
+     */
     private function headerList()
     {
         return new HeaderList($this->headers);
     }
 
+    /**
+     * @return KeyStore
+     */
     private function keyStore()
     {
         if (empty($this->keyStore)) {
@@ -80,6 +113,9 @@ class Context
         return $this->keyStore;
     }
 
+    /**
+     * @param KeyStoreInterface $keyStore
+     */
     private function setKeyStore(KeyStoreInterface $keyStore)
     {
         $this->keyStore = $keyStore;

--- a/src/HeaderList.php
+++ b/src/HeaderList.php
@@ -4,8 +4,12 @@ namespace HttpSignatures;
 
 class HeaderList
 {
+    /** @var array */
     public $names;
 
+    /**
+     * @param array $names
+     */
     public function __construct($names)
     {
         $this->names = array_map(
@@ -14,16 +18,27 @@ class HeaderList
         );
     }
 
+    /**
+     * @param $string
+     * @return HeaderList
+     */
     public static function fromString($string)
     {
         return new static(explode(' ', $string));
     }
 
+    /**
+     * @return string
+     */
     public function string()
     {
         return implode(' ', $this->names);
     }
 
+    /**
+     * @param $name
+     * @return string
+     */
     private function normalize($name)
     {
         return strtolower($name);

--- a/src/HmacAlgorithm.php
+++ b/src/HmacAlgorithm.php
@@ -4,18 +4,30 @@ namespace HttpSignatures;
 
 class HmacAlgorithm
 {
+    /** @var string */
     private $digestName;
 
+    /**
+     * @param string $digestName
+     */
     public function __construct($digestName)
     {
         $this->digestName = $digestName;
     }
 
+    /**
+     * @return string
+     */
     public function name()
     {
         return sprintf('hmac-%s', $this->digestName);
     }
 
+    /**
+     * @param string $key
+     * @param string $data
+     * @return string
+     */
     public function sign($key, $data)
     {
         return hash_hmac($this->digestName, $data, $key, true);

--- a/src/Key.php
+++ b/src/Key.php
@@ -4,9 +4,16 @@ namespace HttpSignatures;
 
 class Key
 {
+    /** @var string */
     public $id;
+
+    /** @var string */
     public $secret;
 
+    /**
+     * @param string $id
+     * @param string $secret
+     */
     public function __construct($id, $secret)
     {
         $this->id = $id;

--- a/src/KeyStore.php
+++ b/src/KeyStore.php
@@ -4,8 +4,12 @@ namespace HttpSignatures;
 
 class KeyStore implements KeyStoreInterface
 {
+    /** @var Key[] */
     private $keys;
 
+    /**
+     * @param array $keys
+     */
     public function __construct($keys)
     {
         $this->keys = array();
@@ -14,6 +18,11 @@ class KeyStore implements KeyStoreInterface
         }
     }
 
+    /**
+     * @param string $keyId
+     * @return Key
+     * @throws KeyStoreException
+     */
     public function fetch($keyId)
     {
         if (isset($this->keys[$keyId])) {

--- a/src/KeyStoreInterface.php
+++ b/src/KeyStoreInterface.php
@@ -6,6 +6,8 @@ interface KeyStoreInterface
 {
     /**
      * return the secret for the specified $keyId
+     * @param string $keyId
+     * @return Key
      */
     public function fetch($keyId);
 }

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -2,13 +2,28 @@
 
 namespace HttpSignatures;
 
+use Symfony\Component\HttpFoundation\Request;
+
 class Signature
 {
+    /** @var Request|SymfonyRequestMessage */
     private $message;
+
+    /** @var Key */
     private $key;
+
+    /** @var HmacAlgorithm */
     private $algorithm;
+
+    /** @var HeaderList */
     private $headerList;
 
+    /**
+     * @param Request|SymfonyRequestMessage $message
+     * @param Key $key
+     * @param HmacAlgorithm $algorithm
+     * @param HeaderList $headerList
+     */
     public function __construct($message, $key, $algorithm, $headerList)
     {
         $this->message = $message;

--- a/src/SignatureParameters.php
+++ b/src/SignatureParameters.php
@@ -4,6 +4,12 @@ namespace HttpSignatures;
 
 class SignatureParameters
 {
+    /**
+     * @param Key $key
+     * @param HmacAlgorithm $algorithm
+     * @param HeaderList $headerList
+     * @param Signature $signature
+     */
     public function __construct($key, $algorithm, $headerList, $signature)
     {
         $this->key = $key;
@@ -12,11 +18,17 @@ class SignatureParameters
         $this->signature = $signature;
     }
 
+    /**
+     * @return string
+     */
     public function string()
     {
         return implode(',', $this->parameterComponents());
     }
 
+    /**
+     * @return array
+     */
     private function parameterComponents()
     {
         return array(
@@ -27,6 +39,9 @@ class SignatureParameters
         );
     }
 
+    /**
+     * @return string
+     */
     private function signatureBase64()
     {
         return base64_encode($this->signature->string());

--- a/src/SignatureParametersParser.php
+++ b/src/SignatureParametersParser.php
@@ -4,13 +4,20 @@ namespace HttpSignatures;
 
 class SignatureParametersParser
 {
+    /** @var string */
     private $input;
 
+    /**
+     * @param string $input
+     */
     public function __construct($input)
     {
         $this->input = $input;
     }
 
+    /**
+     * @return array
+     */
     public function parse()
     {
         $result = $this->pairsToAssociative(
@@ -21,6 +28,10 @@ class SignatureParametersParser
         return $result;
     }
 
+    /**
+     * @param array $pairs
+     * @return array
+     */
     private function pairsToAssociative($pairs)
     {
         $result = array();
@@ -31,6 +42,9 @@ class SignatureParametersParser
         return $result;
     }
 
+    /**
+     * @return array
+     */
     private function arrayOfPairs()
     {
         return array_map(
@@ -39,11 +53,19 @@ class SignatureParametersParser
         );
     }
 
+    /**
+     * @return array
+     */
     private function segments()
     {
         return explode(',', $this->input);
     }
 
+    /**
+     * @param $segment
+     * @return array
+     * @throws SignatureParseException
+     */
     private function pair($segment)
     {
         $segmentPattern = '/\A(keyId|algorithm|headers|signature)="(.*)"\z/';
@@ -57,11 +79,19 @@ class SignatureParametersParser
         return $matches;
     }
 
+    /**
+     * @param $result
+     * @throws SignatureParseException
+     */
     private function validate($result)
     {
         $this->validateAllKeysArePresent($result);
     }
 
+    /**
+     * @param $result
+     * @throws SignatureParseException
+     */
     private function validateAllKeysArePresent($result)
     {
         // Regexp in pair() ensures no unwanted keys exist.

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -4,10 +4,20 @@ namespace HttpSignatures;
 
 class Signer
 {
+    /** @var Key */
     private $key;
+
+    /** @var HmacAlgorithm */
     private $algorithm;
+
+    /** @var HeaderList */
     private $headerList;
 
+    /**
+     * @param Key $key
+     * @param HmacAlgorithm $algorithm
+     * @param HeaderList $headerList
+     */
     public function __construct($key, $algorithm, $headerList)
     {
         $this->key = $key;
@@ -15,6 +25,9 @@ class Signer
         $this->headerList = $headerList;
     }
 
+    /**
+     * @param $message
+     */
     public function sign($message)
     {
         $signatureParameters = $this->signatureParameters($message);
@@ -22,6 +35,10 @@ class Signer
         $message->headers->set("Authorization", "Signature " . $signatureParameters->string());
     }
 
+    /**
+     * @param $message
+     * @return SignatureParameters
+     */
     private function signatureParameters($message)
     {
       return new SignatureParameters(
@@ -32,6 +49,10 @@ class Signer
       );
     }
 
+    /**
+     * @param $message
+     * @return Signature
+     */
     private function signature($message)
     {
         return new Signature(

--- a/src/SigningString.php
+++ b/src/SigningString.php
@@ -6,9 +6,16 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SigningString
 {
+    /** @var HeaderList */
     private $headerList;
+
+    /** @var Request|SymfonyRequestMessage */
     private $message;
 
+    /**
+     * @param HeaderList $headerList
+     * @param Request|SymfonyRequestMessage $message
+     */
     public function __construct($headerList, $message)
     {
         $this->headerList = $headerList;
@@ -19,11 +26,17 @@ class SigningString
         }
     }
 
+    /**
+     * @return string
+     */
     public function string()
     {
         return implode("\n", $this->lines());
     }
 
+    /**
+     * @return array
+     */
     private function lines()
     {
         return array_map(
@@ -32,6 +45,11 @@ class SigningString
         );
     }
 
+    /**
+     * @param string $name
+     * @return string
+     * @throws SignedHeaderNotPresentException
+     */
     private function line($name)
     {
         if ($name == '(request-target)') {
@@ -41,6 +59,11 @@ class SigningString
         }
     }
 
+    /**
+     * @param string $name
+     * @return string
+     * @throws SignedHeaderNotPresentException
+     */
     private function headerValue($name)
     {
         $headers = $this->message->headers;
@@ -51,6 +74,9 @@ class SigningString
         }
     }
 
+    /**
+     * @return string
+     */
     private function requestTargetLine()
     {
         return sprintf(
@@ -60,6 +86,9 @@ class SigningString
         );
     }
 
+    /**
+     * @return string
+     */
     private function getPathWithQueryString()
     {
         $path = $this->message->getPathInfo();

--- a/src/SymfonyRequestMessage.php
+++ b/src/SymfonyRequestMessage.php
@@ -2,22 +2,37 @@
 
 namespace HttpSignatures;
 
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
 class SymfonyRequestMessage
 {
+    /** @var Request */
     private $request;
+
+    /** @var ParameterBag */
     public $headers;
 
+    /**
+     * @param Request $request
+     */
     public function __construct($request)
     {
         $this->request = $request;
         $this->headers = $request->headers;
     }
 
+    /**
+     * @return string
+     */
     public function getPathInfo()
     {
         return $this->request->getPathInfo();
     }
 
+    /**
+     * @return string|null
+     */
     public function getQueryString()
     {
         // Symfony\Component\HttpFoundation\Request::getQueryString() is not
@@ -29,6 +44,9 @@ class SymfonyRequestMessage
         }
     }
 
+    /**
+     * @return string
+     */
     public function getMethod()
     {
         return $this->request->getMethod();

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -2,28 +2,40 @@
 
 namespace HttpSignatures;
 
+use Symfony\Component\HttpFoundation\Request;
+
 class Verification
 {
+    /** @var Request|SymfonyRequestMessage */
     private $message;
 
-    /**
-     * @var KeyStoreInterface
-     */
+    /** @var KeyStoreInterface */
     private $keyStore;
 
+    /** @var array */
     private $_parameters;
 
+    /**
+     * @param Request|SymfonyRequestMessage $message
+     * @param KeyStoreInterface $keyStore
+     */
     public function __construct($message, KeyStoreInterface $keyStore)
     {
         $this->message = $message;
         $this->keyStore = $keyStore;
     }
 
+    /**
+     * @return bool
+     */
     public function isValid()
     {
         return $this->hasSignatureHeader() && $this->signatureMatches();
     }
 
+    /**
+     * @return bool
+     */
     private function signatureMatches()
     {
         try {
@@ -37,11 +49,17 @@ class Verification
         }
     }
 
+    /**
+     * @return string
+     */
     private function expectedSignatureBase64()
     {
         return base64_encode($this->expectedSignature()->string());
     }
 
+    /**
+     * @return Signature
+     */
     private function expectedSignature()
     {
         return new Signature(
@@ -52,26 +70,47 @@ class Verification
         );
     }
 
+    /**
+     * @return string
+     * @throws Exception
+     */
     private function providedSignatureBase64()
     {
         return $this->parameter('signature');
     }
 
+    /**
+     * @return Key
+     * @throws Exception
+     */
     private function key()
     {
         return $this->keyStore->fetch($this->parameter('keyId'));
     }
 
+    /**
+     * @return HmacAlgorithm
+     * @throws Exception
+     */
     private function algorithm()
     {
         return Algorithm::create($this->parameter('algorithm'));
     }
 
+    /**
+     * @return HeaderList
+     * @throws Exception
+     */
     private function headerList()
     {
         return HeaderList::fromString($this->parameter('headers'));
     }
 
+    /**
+     * @param string $name
+     * @return string
+     * @throws Exception
+     */
     private function parameter($name)
     {
         $parameters = $this->parameters();
@@ -82,6 +121,10 @@ class Verification
         return $parameters[$name];
     }
 
+    /**
+     * @return array
+     * @throws Exception
+     */
     private function parameters()
     {
         if (!isset($this->_parameters)) {
@@ -92,11 +135,18 @@ class Verification
         return $this->_parameters;
     }
 
+    /**
+     * @return bool
+     */
     private function hasSignatureHeader()
     {
         return $this->message->headers->has('Signature') || $this->message->headers->has('Authorization');
     }
 
+    /**
+     * @return string
+     * @throws Exception
+     */
     private function signatureHeader()
     {
         if ($signature = $this->fetchHeader('Signature')) {
@@ -108,6 +158,10 @@ class Verification
         }
     }
 
+    /**
+     * @param $name
+     * @return string|null
+     */
     private function fetchHeader($name)
     {
         $headers = $this->message->headers;

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -2,18 +2,25 @@
 
 namespace HttpSignatures;
 
+use Symfony\Component\HttpFoundation\Request;
+
 class Verifier
 {
-    /**
-     * @var KeyStoreInterface
-     */
+    /** @var KeyStoreInterface */
     private $keyStore;
 
+    /**
+     * @param KeyStoreInterface $keyStore
+     */
     public function __construct(KeyStoreInterface $keyStore)
     {
         $this->keyStore = $keyStore;
     }
 
+    /**
+     * @param Request|SymfonyRequestMessage $message
+     * @return bool
+     */
     public function isValid($message)
     {
         $verification = new Verification($message, $this->keyStore);


### PR DESCRIPTION
This PR adds phpDoc to the public methods of most classes and tidies up some internal logic for clarity.

Reasoning: It's nice to know what classes things expect / refer to when using PHP.