### PR TITLE
php-cs-fixer normalized formatting etc.

### DIFF
--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -11,7 +11,9 @@ class Algorithm
 
     /**
      * @param string $name
+     *
      * @return HmacAlgorithm
+     *
      * @throws Exception
      */
     public static function create($name)

--- a/src/Context.php
+++ b/src/Context.php
@@ -18,12 +18,13 @@ class Context
 
     /**
      * @param array $args
+     *
      * @throws Exception
      */
     public function __construct($args)
     {
         if (isset($args['keys']) && isset($args['keyStore'])) {
-            throw new Exception(__CLASS__ . ' accepts keys or keyStore but not both');
+            throw new Exception(__CLASS__.' accepts keys or keyStore but not both');
         } elseif (isset($args['keys'])) {
             // array of keyId => keySecret
             $this->keys = $args['keys'];
@@ -51,6 +52,7 @@ class Context
 
     /**
      * @return Signer
+     *
      * @throws Exception
      */
     public function signer()
@@ -72,6 +74,7 @@ class Context
 
     /**
      * @return Key
+     *
      * @throws Exception
      * @throws KeyStoreException
      */
@@ -86,6 +89,7 @@ class Context
 
     /**
      * @return HmacAlgorithm
+     *
      * @throws Exception
      */
     private function algorithm()

--- a/src/HeaderList.php
+++ b/src/HeaderList.php
@@ -13,13 +13,14 @@ class HeaderList
     public function __construct($names)
     {
         $this->names = array_map(
-            array($this, "normalize"),
+            array($this, 'normalize'),
             $names
         );
     }
 
     /**
      * @param $string
+     *
      * @return HeaderList
      */
     public static function fromString($string)
@@ -37,6 +38,7 @@ class HeaderList
 
     /**
      * @param $name
+     *
      * @return string
      */
     private function normalize($name)

--- a/src/HmacAlgorithm.php
+++ b/src/HmacAlgorithm.php
@@ -26,6 +26,7 @@ class HmacAlgorithm
     /**
      * @param string $key
      * @param string $data
+     *
      * @return string
      */
     public function sign($key, $data)

--- a/src/KeyStore.php
+++ b/src/KeyStore.php
@@ -20,7 +20,9 @@ class KeyStore implements KeyStoreInterface
 
     /**
      * @param string $keyId
+     *
      * @return Key
+     *
      * @throws KeyStoreException
      */
     public function fetch($keyId)

--- a/src/KeyStoreInterface.php
+++ b/src/KeyStoreInterface.php
@@ -5,8 +5,10 @@ namespace HttpSignatures;
 interface KeyStoreInterface
 {
     /**
-     * return the secret for the specified $keyId
+     * return the secret for the specified $keyId.
+     *
      * @param string $keyId
+     *
      * @return Key
      */
     public function fetch($keyId);

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -20,9 +20,9 @@ class Signature
 
     /**
      * @param Request|SymfonyRequestMessage $message
-     * @param Key $key
-     * @param HmacAlgorithm $algorithm
-     * @param HeaderList $headerList
+     * @param Key                           $key
+     * @param HmacAlgorithm                 $algorithm
+     * @param HeaderList                    $headerList
      */
     public function __construct($message, $key, $algorithm, $headerList)
     {

--- a/src/SignatureParameters.php
+++ b/src/SignatureParameters.php
@@ -5,10 +5,10 @@ namespace HttpSignatures;
 class SignatureParameters
 {
     /**
-     * @param Key $key
+     * @param Key           $key
      * @param HmacAlgorithm $algorithm
-     * @param HeaderList $headerList
-     * @param Signature $signature
+     * @param HeaderList    $headerList
+     * @param Signature     $signature
      */
     public function __construct($key, $algorithm, $headerList, $signature)
     {

--- a/src/SignatureParametersParser.php
+++ b/src/SignatureParametersParser.php
@@ -30,6 +30,7 @@ class SignatureParametersParser
 
     /**
      * @param array $pairs
+     *
      * @return array
      */
     private function pairsToAssociative($pairs)
@@ -63,7 +64,9 @@ class SignatureParametersParser
 
     /**
      * @param $segment
+     *
      * @return array
+     *
      * @throws SignatureParseException
      */
     private function pair($segment)
@@ -81,6 +84,7 @@ class SignatureParametersParser
 
     /**
      * @param $result
+     *
      * @throws SignatureParseException
      */
     private function validate($result)
@@ -90,6 +94,7 @@ class SignatureParametersParser
 
     /**
      * @param $result
+     *
      * @throws SignatureParseException
      */
     private function validateAllKeysArePresent($result)

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -14,9 +14,9 @@ class Signer
     private $headerList;
 
     /**
-     * @param Key $key
+     * @param Key           $key
      * @param HmacAlgorithm $algorithm
-     * @param HeaderList $headerList
+     * @param HeaderList    $headerList
      */
     public function __construct($key, $algorithm, $headerList)
     {
@@ -31,17 +31,18 @@ class Signer
     public function sign($message)
     {
         $signatureParameters = $this->signatureParameters($message);
-        $message->headers->set("Signature", $signatureParameters->string());
-        $message->headers->set("Authorization", "Signature " . $signatureParameters->string());
+        $message->headers->set('Signature', $signatureParameters->string());
+        $message->headers->set('Authorization', 'Signature '.$signatureParameters->string());
     }
 
     /**
      * @param $message
+     *
      * @return SignatureParameters
      */
     private function signatureParameters($message)
     {
-      return new SignatureParameters(
+        return new SignatureParameters(
         $this->key,
         $this->algorithm,
         $this->headerList,
@@ -51,6 +52,7 @@ class Signer
 
     /**
      * @param $message
+     *
      * @return Signature
      */
     private function signature($message)

--- a/src/SigningString.php
+++ b/src/SigningString.php
@@ -13,7 +13,7 @@ class SigningString
     private $message;
 
     /**
-     * @param HeaderList $headerList
+     * @param HeaderList                    $headerList
      * @param Request|SymfonyRequestMessage $message
      */
     public function __construct($headerList, $message)
@@ -47,7 +47,9 @@ class SigningString
 
     /**
      * @param string $name
+     *
      * @return string
+     *
      * @throws SignedHeaderNotPresentException
      */
     private function line($name)
@@ -61,7 +63,9 @@ class SigningString
 
     /**
      * @param string $name
+     *
      * @return string
+     *
      * @throws SignedHeaderNotPresentException
      */
     private function headerValue($name)

--- a/src/SymfonyRequestMessage.php
+++ b/src/SymfonyRequestMessage.php
@@ -38,7 +38,7 @@ class SymfonyRequestMessage
         // Symfony\Component\HttpFoundation\Request::getQueryString() is not
         // suitable for HTTP signatures as it mangles the query string.
         if ($this->request->getQueryString() === null) {
-            return null;
+            return;
         } else {
             return $this->request->server->get('QUERY_STRING');
         }

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -17,7 +17,7 @@ class Verification
 
     /**
      * @param Request|SymfonyRequestMessage $message
-     * @param KeyStoreInterface $keyStore
+     * @param KeyStoreInterface             $keyStore
      */
     public function __construct($message, KeyStoreInterface $keyStore)
     {
@@ -72,6 +72,7 @@ class Verification
 
     /**
      * @return string
+     *
      * @throws Exception
      */
     private function providedSignatureBase64()
@@ -81,6 +82,7 @@ class Verification
 
     /**
      * @return Key
+     *
      * @throws Exception
      */
     private function key()
@@ -90,6 +92,7 @@ class Verification
 
     /**
      * @return HmacAlgorithm
+     *
      * @throws Exception
      */
     private function algorithm()
@@ -99,6 +102,7 @@ class Verification
 
     /**
      * @return HeaderList
+     *
      * @throws Exception
      */
     private function headerList()
@@ -108,7 +112,9 @@ class Verification
 
     /**
      * @param string $name
+     *
      * @return string
+     *
      * @throws Exception
      */
     private function parameter($name)
@@ -123,6 +129,7 @@ class Verification
 
     /**
      * @return array
+     *
      * @throws Exception
      */
     private function parameters()
@@ -145,26 +152,29 @@ class Verification
 
     /**
      * @return string
+     *
      * @throws Exception
      */
     private function signatureHeader()
     {
         if ($signature = $this->fetchHeader('Signature')) {
             return $signature;
-        } else if ($authorization = $this->fetchHeader('Authorization')) {
+        } elseif ($authorization = $this->fetchHeader('Authorization')) {
             return substr($authorization, strlen('Signature '));
         } else {
-            throw new Exception("HTTP message has no Signature or Authorization header");
+            throw new Exception('HTTP message has no Signature or Authorization header');
         }
     }
 
     /**
      * @param $name
+     *
      * @return string|null
      */
     private function fetchHeader($name)
     {
         $headers = $this->message->headers;
+
         return $headers->has($name) ? $headers->get($name) : null;
     }
 }

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -19,6 +19,7 @@ class Verifier
 
     /**
      * @param Request|SymfonyRequestMessage $message
+     *
      * @return bool
      */
     public function isValid($message)


### PR DESCRIPTION
Addendum to #13; automated reformatting by [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).

    $ php-cs-fixer --version
    PHP CS Fixer version 1.10 by Fabien Potencier

    $ php-cs-fixer fix src/
       1) Algorithm.php
       2) Context.php
       3) HeaderList.php
       4) HmacAlgorithm.php
       5) KeyStore.php
       6) KeyStoreInterface.php
       7) Signature.php
       8) SignatureParameters.php
       9) SignatureParametersParser.php
      10) Signer.php
      11) SigningString.php
      12) SymfonyRequestMessage.php
      13) Verification.php
      14) Verifier.php
    Fixed all files in 4.107 seconds, 6.250 MB memory used