### PR TITLE
Allow more Major Versions of Symfony Component to allow for Laravel 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-foundation": "~2.5|~3.0.0"
+        "symfony/http-foundation": "~2.5|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1"


### PR DESCRIPTION
Laravel 5.3 requires Symfony Components v3.1.x which current constraint of ~3.0.0 will not allow.