### PR TITLE
Remove support for < PHP 5.5 and older Symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -12,16 +10,5 @@ install: composer require --no-update symfony/http-foundation $SYMFONY_VERSION; 
 script: vendor/bin/phpunit
 
 env:
-  - SYMFONY_VERSION: ~2.5.0
-  - SYMFONY_VERSION: ~2.6.0
-  - SYMFONY_VERSION: ~2.7.0
   - SYMFONY_VERSION: ~2.8.0
   - SYMFONY_VERSION: ~3.0.0
-
-
-matrix:
-  exclude:
-    - php: 5.3
-      env: SYMFONY_VERSION=~3.0.0
-    - php: 5.4
-      env: SYMFONY_VERSION=~3.0.0

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         }
     },
     "require": {
-        "php": ">=5.3.3",
-        "symfony/http-foundation": "~2.5|~3.0"
+        "php": ">=5.5",
+        "symfony/http-foundation": "~2.8|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1"
+        "phpunit/phpunit": "~4.8"
     }
 }


### PR DESCRIPTION
This PR removes support for versions of PHP before 5.5 and versions of Symfony below 2.8

The reasoning behind this is:

- PHP 5.5 is close to end of life
- numerous libraries only support 5.5 and up
- We're aiming for a 2.0 release, so now is the time for non BC dependency updates