### PR TITLE
Use RequestInterface instead of MessageInterface

### DIFF
--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -6,9 +6,7 @@ abstract class Algorithm
 {
     /**
      * @param string $name
-     *
      * @return HmacAlgorithm
-     *
      * @throws Exception
      */
     public static function create($name)

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -2,7 +2,7 @@
 
 namespace HttpSignatures;
 
-use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
 
 class Signature
 {
@@ -16,12 +16,12 @@ class Signature
     private $signingString;
 
     /**
-     * @param MessageInterface $message
+     * @param RequestInterface $message
      * @param Key $key
      * @param AlgorithmInterface $algorithm
      * @param HeaderList $headerList
      */
-    public function __construct(MessageInterface $message, Key $key, AlgorithmInterface $algorithm, HeaderList $headerList)
+    public function __construct($message, Key $key, AlgorithmInterface $algorithm, HeaderList $headerList)
     {
         $this->key = $key;
         $this->algorithm = $algorithm;

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -2,7 +2,7 @@
 
 namespace HttpSignatures;
 
-use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
 
 class Signer
 {
@@ -28,10 +28,10 @@ class Signer
     }
 
     /**
-     * @param MessageInterface $message
-     * @return MessageInterface
+     * @param RequestInterface $message
+     * @return RequestInterface
      */
-    public function sign(MessageInterface $message)
+    public function sign($message)
     {
         $signatureParameters = $this->signatureParameters($message);
         $message = $message->withAddedHeader("Signature", $signatureParameters->string());
@@ -40,7 +40,7 @@ class Signer
     }
 
     /**
-     * @param MessageInterface $message
+     * @param RequestInterface $message
      * @return SignatureParameters
      */
     private function signatureParameters($message)
@@ -54,7 +54,7 @@ class Signer
     }
 
     /**
-     * @param MessageInterface $message
+     * @param RequestInterface $message
      * @return Signature
      */
     private function signature($message)

--- a/src/SigningString.php
+++ b/src/SigningString.php
@@ -16,7 +16,7 @@ class SigningString
      * @param HeaderList $headerList
      * @param RequestInterface $message
      */
-    public function __construct(HeaderList $headerList, RequestInterface $message)
+    public function __construct(HeaderList $headerList, $message)
     {
         $this->headerList = $headerList;
         $this->message = $message;

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -2,11 +2,11 @@
 
 namespace HttpSignatures;
 
-use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
 
 class Verification
 {
-    /** @var MessageInterface */
+    /** @var RequestInterface */
     private $message;
 
     /** @var KeyStoreInterface */
@@ -16,10 +16,10 @@ class Verification
     private $_parameters;
 
     /**
-     * @param MessageInterface $message
+     * @param RequestInterface $message
      * @param KeyStoreInterface $keyStore
      */
-    public function __construct(MessageInterface $message, $keyStore)
+    public function __construct($message, KeyStoreInterface $keyStore)
     {
         $this->message = $message;
         $this->keyStore = $keyStore;

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -2,7 +2,7 @@
 
 namespace HttpSignatures;
 
-use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
 
 class Verifier
 {
@@ -18,10 +18,10 @@ class Verifier
     }
 
     /**
-     * @param MessageInterface $message
+     * @param RequestInterface $message
      * @return bool
      */
-    public function isValid(MessageInterface $message)
+    public function isValid($message)
     {
         $verification = new Verification($message, $this->keyStore);
 


### PR DESCRIPTION
Currently, this library uses the following request methods:

- `hasHeader`
- `getHeader`
- `withAddedHeader`
- `getUri`
- `getMethod`

The first three are defined as part of `Psr\Http\Message\MessageInterface`, but the last two methods are defined as part of `Psr\Http\Message\RequestInterface`. So, this PR updates the various phpDoc statements to reference `RequestInterface` instead.

It also removes the type hinting from method signatures for the PSR-7 interfaces. We use such a small subset of the PSR-7 spec, that enforcing that anything passed into these methods matches these interfaces seems like overkill and makes writing code that integrates with this library a pain.