### PR TITLE
Avoid timing side channels in signature validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require": {
         "php": ">=5.5",
+        "paragonie/random_compat": "^1.0|^2.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "psr/http-message": "^1.0",
         "symfony/psr-http-message-bridge": "^1.0",

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -39,7 +39,8 @@ class Verification
     private function signatureMatches()
     {
         try {
-            return $this->expectedSignatureBase64() === $this->providedSignatureBase64();
+            $random = random_bytes(32);
+            return hash_hmac('sha256', $this->expectedSignatureBase64(), $random, true) === hash_hmac('sha256', $this->providedSignatureBase64(), $random, true);
         } catch (SignatureParseException $e) {
             return false;
         } catch (KeyStoreException $e) {


### PR DESCRIPTION
Use a blinded HMAC comparison to verify signatures, which avoids timing side-channel's through use of ===. See https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy for more details

This PR introduces a dependency on `paragonie/random_compat`, which adds a polyfill for `random_bytes` from PHP7. It doesn't affect PHP7+ installs, but is the recommended way to scramble for random data on older systems. 

Happy to submit some backports if required.