### PR TITLE
SigningString: use getRequestTarget not getPath & getQuery.

### DIFF
--- a/src/SigningString.php
+++ b/src/SigningString.php
@@ -78,21 +78,7 @@ class SigningString
         return sprintf(
             '(request-target): %s %s',
             strtolower($this->message->getMethod()),
-            $this->getPathWithQueryString()
+            $this->message->getRequestTarget()
         );
-    }
-
-    /**
-     * @return string
-     */
-    private function getPathWithQueryString()
-    {
-        $path = $this->message->getUri()->getPath();
-        $qs = $this->message->getUri()->getQuery();
-        if (empty($qs)) {
-            return $path;
-        } else {
-            return "$path?$qs";
-        }
     }
 }


### PR DESCRIPTION
Verifying HTTP Signatures on requests received via Symfony apps was failing when Symfony re-ordered the query string parameters (alphabetic by key).

This PR uses `Psr\Http\Message\RequestInterface::getRequestTarget()` (see http://www.php-fig.org/psr/psr-7/) to generate the HTTP Signatures request target instead of manually stitching together path and query, making it easier to pass the correct non-normalized request target.