### PR TITLE
Separate functions to generate Signature and Authorization headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - "7.0"
   - "7.1"
   - "7.2"
+  - "7.3"
 
 install:
   - composer require --no-update symfony/http-foundation $SYMFONY_VERSION; composer install
@@ -17,3 +18,11 @@ env:
   - SYMFONY_VERSION: ~2
   - SYMFONY_VERSION: ~3
   - SYMFONY_VERSION: ~4
+
+matrix:
+  exclude:
+  - php: "5.6"
+    env: SYMFONY_VERSION=~4
+  - php: "7.0"
+    env: SYMFONY_VERSION=~4
+

--- a/phpunit
+++ b/phpunit
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo 'vendor/bin/phpunit && vendor/bin/php-cs-fixer fix -v --dry-run'
+vendor/bin/phpunit && vendor/bin/php-cs-fixer fix -v --dry-run
+

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -43,6 +43,17 @@ class Signer
 
     /**
      * @param RequestInterface $message
+     * @return RequestInterface
+     */
+    public function authorize($message)
+    {
+        $signatureParameters = $this->signatureParameters($message);
+        $message = $message->withAddedHeader("Authorization", "Signature " . $signatureParameters->string());
+        return $message;
+    }
+
+    /**
+     * @param RequestInterface $message
      *
      * @return RequestInterface
      */

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -43,12 +43,14 @@ class Signer
 
     /**
      * @param RequestInterface $message
+     *
      * @return RequestInterface
      */
     public function authorize($message)
     {
         $signatureParameters = $this->signatureParameters($message);
-        $message = $message->withAddedHeader("Authorization", "Signature " . $signatureParameters->string());
+        $message = $message->withAddedHeader('Authorization', 'Signature '.$signatureParameters->string());
+
         return $message;
     }
 

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -36,7 +36,6 @@ class Signer
     {
         $signatureParameters = $this->signatureParameters($message);
         $message = $message->withAddedHeader('Signature', $signatureParameters->string());
-        $message = $message->withAddedHeader('Authorization', 'Signature '.$signatureParameters->string());
 
         return $message;
     }

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -50,12 +50,11 @@ class Verification
     private function signatureMatches()
     {
         try {
-            $random = random_bytes(32);
-
-            return
-                hash_hmac('sha256', $this->expectedSignatureBase64(), $random, true) ===
-                hash_hmac('sha256', $this->providedSignatureBase64(), $random, true)
-            ;
+            // hash_equals is a timing-attack resistant string comparitor
+            return hash_equals(
+                $this->expectedSignatureBase64(),
+                $this->providedSignatureBase64()
+            );
         } catch (SignatureParseException $e) {
             return false;
         } catch (KeyStoreException $e) {
@@ -71,11 +70,11 @@ class Verification
     private function authorizationMatches()
     {
         try {
-            $random = random_bytes(32);
-
-            return
-              hash_hmac('sha256', $this->expectedAuthorizationBase64(), $random, true) ===
-              hash_hmac('sha256', $this->providedAuthorizationBase64(), $random, true);
+            // hash_equals is a timing-attack resistant string comparitor
+            return hash_equals(
+                $this->expectedAuthorizationBase64(),
+                $this->providedAuthorizationBase64()
+            );
         } catch (SignatureParseException $e) {
             return false;
         } catch (KeyStoreException $e) {

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -69,6 +69,7 @@ class Verification
     {
         try {
             $random = random_bytes(32);
+
             return
               hash_hmac('sha256', $this->expectedAuthorizationBase64(), $random, true) ===
               hash_hmac('sha256', $this->providedAuthorizationBase64(), $random, true);

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -31,6 +31,7 @@ class Verifier
 
     /**
      * @param RequestInterface $message
+     *
      * @return bool
      */
     public function isAuthorized($message)

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -48,12 +48,12 @@ class Verifier
      */
     public function isValid($message)
     {
-        trigger_error (
-            "http-signatures-php: Verifier->isValid() is deprecated, use isSigned() or isAuthorized() to validate individual signature header",
+        trigger_error(
+            'http-signatures-php: Verifier->isValid() is deprecated, use isSigned() or isAuthorized() to validate individual signature header',
              E_USER_DEPRECATED
         );
         $verification = new Verification($message, $this->keyStore);
 
-        return ( $verification->isAuthorized() && $verification->isSigned() );
+        return  $verification->isAuthorized() && $verification->isSigned();
     }
 }

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -40,4 +40,20 @@ class Verifier
 
         return $verification->isAuthorized();
     }
+
+    /**
+     * @param RequestInterface $message
+     *
+     * @return bool
+     */
+    public function isValid($message)
+    {
+        trigger_error (
+            "http-signatures-php: Verifier->isValid() is deprecated, use isSigned() or isAuthorized() to validate individual signature header",
+             E_USER_DEPRECATED
+        );
+        $verification = new Verification($message, $this->keyStore);
+
+        return ( $verification->isAuthorized() && $verification->isSigned() );
+    }
 }

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -22,10 +22,21 @@ class Verifier
      *
      * @return bool
      */
-    public function isValid($message)
+    public function isSigned($message)
     {
         $verification = new Verification($message, $this->keyStore);
 
-        return $verification->isValid();
+        return $verification->isSigned();
+    }
+
+    /**
+     * @param RequestInterface $message
+     * @return bool
+     */
+    public function isAuthorized($message)
+    {
+        $verification = new Verification($message, $this->keyStore);
+
+        return $verification->isAuthorized();
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -25,9 +25,11 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
     public function testSignerNoDigestAction()
     {
-        $message = new Request('GET', '/path?query=123', ['date' => 'today', 'accept' => 'llamas']);
-        $message = $this->noDigestContext->signer()->sign($message);
-
+        $authorizeHeaderString = 'Bearer abc456';
+        $message = new Request(
+          'GET', '/path?query=123',
+          ['date' => 'today', 'accept' => 'llamas', 'Authorize' => $authorizeHeaderString]);
+        $message = $this->context->signer()->sign($message);
         $expectedString = implode(',', [
             'keyId="pda"',
             'algorithm="hmac-sha256"',
@@ -39,6 +41,11 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $expectedString,
             $message->getHeader('Signature')[0]
         );
+        $this->assertEquals(
+            $authorizeHeaderString,
+            $message->getHeader('Authorize')[0]
+        );
+        $this->assertEquals(1, count($message->getHeader('Authorize')));
     }
 
     public function testAuthorizer()

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -29,7 +29,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         $message = new Request(
           'GET', '/path?query=123',
           ['date' => 'today', 'accept' => 'llamas', 'Authorize' => $authorizeHeaderString]);
-        $message = $this->context->signer()->sign($message);
+        $message = $this->noDigestContext->signer()->sign($message);
         $expectedString = implode(',', [
             'keyId="pda"',
             'algorithm="hmac-sha256"',
@@ -51,7 +51,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     public function testAuthorizer()
     {
         $message = new Request('GET', '/path?query=123', ['date' => 'today', 'accept' => 'llamas']);
-        $message = $this->context->signer()->authorize($message);
+        $message = $this->noDigestContext->signer()->authorize($message);
 
         $expectedString = implode(',', [
             'keyId="pda"',
@@ -206,17 +206,17 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         ]));
 
         // assert it works without errors; correctness of results tested elsewhere.
-        $this->assertTrue(is_bool($this->context->verifier()->isSigned($message)));
+        $this->assertTrue(is_bool($this->noDigestContext->verifier()->isSigned($message)));
     }
 
     public function testAuthorizationVerifier()
     {
-        $message = $this->context->signer()->authorize(new Request('GET', '/path?query=123', [
+        $message = $this->noDigestContext->signer()->authorize(new Request('GET', '/path?query=123', [
             'Signature' => 'keyId="pda",algorithm="hmac-sha1",headers="date",signature="x"',
             'Date' => 'x',
         ]));
 
         // assert it works without errors; correctness of results tested elsewhere.
-        $this->assertTrue(is_bool($this->context->verifier()->isAuthorized($message)));
+        $this->assertTrue(is_bool($this->noDigestContext->verifier()->isAuthorized($message)));
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -191,7 +191,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     }
 
 
-    public function testVerifier()
+    public function testSignatureVerifier()
     {
         $message = $this->noDigestContext->signer()->sign(new Request('GET', '/path?query=123', [
             'Signature' => 'keyId="pda",algorithm="hmac-sha1",headers="date",signature="x"',
@@ -199,6 +199,17 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         ]));
 
         // assert it works without errors; correctness of results tested elsewhere.
-        $this->assertTrue(is_bool($this->noDigestContext->verifier()->isValid($message)));
+        $this->assertTrue(is_bool($this->context->verifier()->isSigned($message)));
+    }
+
+    public function testAuthorizationVerifier()
+    {
+        $message = $this->context->signer()->authorize(new Request('GET', '/path?query=123', [
+            'Signature' => 'keyId="pda",algorithm="hmac-sha1",headers="date",signature="x"',
+            'Date' => 'x',
+        ]));
+
+        // assert it works without errors; correctness of results tested elsewhere.
+        $this->assertTrue(is_bool($this->context->verifier()->isAuthorized($message)));
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -39,6 +39,19 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $expectedString,
             $message->getHeader('Signature')[0]
         );
+    }
+
+    public function testAuthorizer()
+    {
+        $message = new Request('GET', '/path?query=123', ['date' => 'today', 'accept' => 'llamas']);
+        $message = $this->context->signer()->authorize($message);
+
+        $expectedString = implode(',', [
+            'keyId="pda"',
+            'algorithm="hmac-sha256"',
+            'headers="(request-target) date"',
+            'signature="SFlytCGpsqb/9qYaKCQklGDvwgmrwfIERFnwt+yqPJw="',
+        ]);
 
         $this->assertEquals(
             'Signature '.$expectedString,
@@ -176,6 +189,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $message->getHeader('Authorization')[0]
         );
     }
+
 
     public function testVerifier()
     {

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -64,6 +64,10 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             'Signature '.$expectedString,
             $message->getHeader('Authorization')[0]
         );
+
+        $this->assertFalse(
+            $message->hasHeader('Signature')
+        );
     }
 
     public function testSignerAddDigestToHeadersList()
@@ -92,9 +96,8 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $message->getHeader('Digest')[0]
         );
 
-        $this->assertEquals(
-            'Signature '.$expectedString,
-            $message->getHeader('Authorization')[0]
+        $this->assertFalse(
+            $message->hasHeader('Authorization')
         );
     }
 
@@ -126,9 +129,8 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $message->getHeader('Digest')[0]
         );
 
-        $this->assertEquals(
-            'Signature '.$expectedString,
-            $message->getHeader('Authorization')[0]
+        $this->assertFalse(
+            $message->hasHeader('Authorization')
         );
     }
 
@@ -159,9 +161,8 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $message->getHeader('Digest')[0]
         );
 
-        $this->assertEquals(
-            'Signature '.$expectedString,
-            $message->getHeader('Authorization')[0]
+        $this->assertFalse(
+            $message->hasHeader('Authorization')
         );
     }
 
@@ -191,9 +192,8 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $message->getHeader('Digest')[0]
         );
 
-        $this->assertEquals(
-            'Signature '.$expectedString,
-            $message->getHeader('Authorization')[0]
+        $this->assertFalse(
+            $message->hasHeader('Authorization')
         );
     }
 

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -197,7 +197,6 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-
     public function testSignatureVerifier()
     {
         $message = $this->noDigestContext->signer()->sign(new Request('GET', '/path?query=123', [

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -125,7 +125,7 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
      */
     public function testLegacyIsValidEmitsDeprecatedWarning()
     {
-        $this->assertTrue($this->verifier->isValid($this->$signedAndAuthorizedMessage));
+        $this->assertTrue($this->verifier->isValid($this->signedAndAuthorizedMessage));
     }
 
     public function testRejectOnlySignatureHeaderAsAuthorized()

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -73,15 +73,13 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testVerifyValidMessageSignatureHeader()
+    public function testVerifyValidSignedMessage()
     {
         $this->assertTrue($this->verifier->isSigned($this->signedMessage));
     }
 
-    public function testVerifyValidMessageAuthorizationHeader()
+    public function testVerifyValidAuthorizedMessage()
     {
-        // $message = $this->message->withHeader('Authorization', "Signature {$this->message->getHeader('Signature')[0]}");
-        // $message = $message->withoutHeader('Signature');
         $this->assertTrue($this->verifier->isAuthorized($this->authorizedMessage));
     }
 

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -50,9 +50,9 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->signedMessage = new Request('GET', '/path?query=123', [
-            "Date" => self::DATE,
-            "Signature" => $signatureHeader,
-            "Authorization" => "Bearer abc123"
+            'Date' => self::DATE,
+            'Signature' => $signatureHeader,
+            'Authorization' => 'Bearer abc123',
         ]);
     }
 
@@ -60,16 +60,16 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
     {
         $authorizationHeader = sprintf(
             'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"',
-            "pda",
-            "hmac-sha256",
-            "(request-target) date",
-            "cS2VvndvReuTLy52Ggi4j6UaDqGm9hMb4z0xJZ6adqU="
+            'pda',
+            'hmac-sha256',
+            '(request-target) date',
+            'cS2VvndvReuTLy52Ggi4j6UaDqGm9hMb4z0xJZ6adqU='
         );
 
         $this->authorizedMessage = new Request('GET', '/path?query=123', [
-            "Date" => self::DATE,
-            "Authorization" => $authorizationHeader,
-            "Signature" => "My Lawyer signed this"
+            'Date' => self::DATE,
+            'Authorization' => $authorizationHeader,
+            'Signature' => 'My Lawyer signed this',
         ]);
     }
 


### PR DESCRIPTION
* Different use cases for each (authorisation vs digital signatures)
* Different meanings deserve distinct flows
* A Signature may need to be be added to a message with an existing Authorization header so can't presume we can simply generate both on every invocation