### PR TITLE
Auto Digest header addition

### DIFF
--- a/src/Signer.php
+++ b/src/Signer.php
@@ -34,15 +34,22 @@ class Signer
      * @param RequestInterface $message
      * @return RequestInterface
      */
-    public function sign($message, $withDigest = false)
+    public function sign($message)
     {
-        if ($withDigest) {
-            $message = $this->addDigest($message);
-        };
         $signatureParameters = $this->signatureParameters($message);
         $message = $message->withAddedHeader("Signature", $signatureParameters->string());
         $message = $message->withAddedHeader("Authorization", "Signature " . $signatureParameters->string());
         return $message;
+    }
+
+    /**
+     * @param RequestInterface $message
+     * @return RequestInterface
+     */
+    public function signWithDigest($message)
+    {
+        $message = $this->addDigest($message);
+        return $this->sign($message);
     }
 
     /**

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -37,7 +37,7 @@ class Signer
     public function sign($message, $withDigest = false)
     {
         if ($withDigest) {
-          $message = $this->addDigest($message);
+            $message = $this->addDigest($message);
         };
         $signatureParameters = $this->signatureParameters($message);
         $message = $message->withAddedHeader("Signature", $signatureParameters->string());
@@ -49,22 +49,23 @@ class Signer
      * @param RequestInterface $message
      * @return RequestInterface
      */
-    private function addDigest($message) {
-      if (!array_search('digest', $this->headerList->names) ) {
-        $this->headerList->names[] = 'digest';
-      };
-      while ($message->getHeader('Digest')) {
-        $message = $message->withoutHeader('Digest');
-      };
-      $message = $message->withHeader(
+    private function addDigest($message)
+    {
+        if (!array_search('digest', $this->headerList->names)) {
+            $this->headerList->names[] = 'digest';
+        };
+        while ($message->getHeader('Digest')) {
+            $message = $message->withoutHeader('Digest');
+        };
+        $message = $message->withHeader(
         'Digest',
         self::defaultHttpDigestPrefix . '=' . base64_encode(
           hash(
-            self::defaultHttpDigest,$message->getBody(), true
+            self::defaultHttpDigest, $message->getBody(), true
           )
         )
       );
-      return $message;
+        return $message;
     }
 
     /**

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -60,13 +60,10 @@ class Signer
         };
         $message = $message->withoutHeader('Digest')
             ->withHeader(
-              'Digest',
-              'SHA-256=' . base64_encode(
-                hash(
-                  'sha256', $message->getBody(), true
-                )
-              )
+                'Digest',
+                'SHA-256=' . base64_encode(hash('sha256', $message->getBody(), true))
             );
+
         return $message;
     }
 

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -6,9 +6,6 @@ use Psr\Http\Message\RequestInterface;
 
 class Signer
 {
-    const defaultHttpDigest       = 'sha256';
-    const defaultHttpDigestPrefix = 'SHA-256';
-
     /** @var Key */
     private $key;
 
@@ -61,17 +58,15 @@ class Signer
         if (!array_search('digest', $this->headerList->names)) {
             $this->headerList->names[] = 'digest';
         };
-        while ($message->getHeader('Digest')) {
-            $message = $message->withoutHeader('Digest');
-        };
-        $message = $message->withHeader(
-        'Digest',
-        self::defaultHttpDigestPrefix . '=' . base64_encode(
-          hash(
-            self::defaultHttpDigest, $message->getBody(), true
-          )
-        )
-      );
+        $message = $message->withoutHeader('Digest')
+            ->withHeader(
+              'Digest',
+              'SHA-256=' . base64_encode(
+                hash(
+                  'sha256', $message->getBody(), true
+                )
+              )
+            );
         return $message;
     }
 

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -52,7 +52,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             'GET', '/path?query=123',
             ['date' => 'today', 'accept' => 'llamas'],
             'This is a body');
-        $message = $this->noDigestContext->signer()->sign($message, true);
+        $message = $this->noDigestContext->signer()->signWithDigest($message);
 
         $expectedString = implode(',', [
             'keyId="pda"',
@@ -86,7 +86,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
               'accept' => 'llamas',
               'Digest' => 'SHA-256=E/P+4y4x6EySO9qNAjCtQKxVwE1xKsNI/k+cjK+vtLU='],
             'This is a body');
-        $message = $this->noDigestContext->signer()->sign($message, true);
+        $message = $this->noDigestContext->signer()->signWithDigest($message);
 
         $expectedString = implode(',', [
             'keyId="pda"',
@@ -119,7 +119,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
               ['date' => 'today',
               'accept' => 'llamas'],
             'This is a body');
-        $message = $this->withDigestContext->signer()->sign($message, true);
+        $message = $this->withDigestContext->signer()->signWithDigest($message);
 
         $expectedString = implode(',', [
             'keyId="pda"',

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -49,18 +49,18 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     public function testSignerAddDigestToHeadersList()
     {
         $message = new Request(
-            'GET', '/path?query=123',
+            'POST', '/path/to/things?query=123',
             ['date' => 'today', 'accept' => 'llamas'],
-            'This is a body');
+            'Thing to POST');
         $message = $this->noDigestContext->signer()->signWithDigest($message);
 
         $expectedString = implode(',', [
             'keyId="pda"',
             'algorithm="hmac-sha256"',
             'headers="(request-target) date digest"',
-            'signature="XihRwDYmFZCLX7us8S+ScqTLo8glcPgm5WXNRxUN9xs="']);
+            'signature="HH6R3OJmJbKUFqqL0tGVIIb7xi1WbbSh/HBXHUtLkUs="']);
         $expectedDigestHeader =
-          'SHA-256=8qVirT1Mv9ZqQhA8DrGKEvIIPPm7HmhQ0Hl4UFTBfsQ=';
+          'SHA-256=rEcNhYZoBKiR29D30w1JcgArNlF8rXIXf5MnIL/4kcc=';
 
         $this->assertEquals(
             $expectedString,
@@ -81,20 +81,20 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     public function testSignerReplaceDigest()
     {
         $message = new Request(
-            'GET', '/path?query=123',
+            'PUT', '/things/thething?query=123',
               ['date' => 'today',
               'accept' => 'llamas',
               'Digest' => 'SHA-256=E/P+4y4x6EySO9qNAjCtQKxVwE1xKsNI/k+cjK+vtLU='],
-            'This is a body');
+            'Thing to PUT at /things/thething please...');
         $message = $this->noDigestContext->signer()->signWithDigest($message);
 
         $expectedString = implode(',', [
             'keyId="pda"',
             'algorithm="hmac-sha256"',
             'headers="(request-target) date digest"',
-            'signature="XihRwDYmFZCLX7us8S+ScqTLo8glcPgm5WXNRxUN9xs="']);
+            'signature="Hyatt1lSR/4XLI9Gcx8XOEKiG8LVktH7Lfr+0tmhwRU="']);
         $expectedDigestHeader =
-          'SHA-256=8qVirT1Mv9ZqQhA8DrGKEvIIPPm7HmhQ0Hl4UFTBfsQ=';
+          'SHA-256=mulOx+77mQU1EbPET50SCGA4P/4bYxVCJA1pTwJsaMw=';
 
         $this->assertEquals(
             $expectedString,
@@ -115,19 +115,19 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     public function testSignerNewDigestIsInHeaderList()
     {
         $message = new Request(
-            'GET', '/path?query=123',
+            'POST', '/path?query=123',
               ['date' => 'today',
               'accept' => 'llamas'],
-            'This is a body');
+            'Stuff that belongs in /path');
         $message = $this->withDigestContext->signer()->signWithDigest($message);
 
         $expectedString = implode(',', [
             'keyId="pda"',
             'algorithm="hmac-sha256"',
             'headers="(request-target) date digest"',
-            'signature="XihRwDYmFZCLX7us8S+ScqTLo8glcPgm5WXNRxUN9xs="']);
+            'signature="p8gQHs59X2WzQLUecfmxm1YO0OBTCNKldRZZBQsepfk="']);
         $expectedDigestHeader =
-          'SHA-256=8qVirT1Mv9ZqQhA8DrGKEvIIPPm7HmhQ0Hl4UFTBfsQ=';
+          'SHA-256=jnSMEfBSum4Rh2k6/IVFyvLuQLmGYwMAGBS9WybyDqQ=';
 
         $this->assertEquals(
             $expectedString,
@@ -144,6 +144,39 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $message->getHeader('Authorization')[0]
         );
     }
+
+    public function testSignerNewDigestWithoutBody()
+    {
+        $message = new Request(
+            'GET', '/path?query=123',
+              ['date' => 'today',
+              'accept' => 'llamas']);
+        $message = $this->withDigestContext->signer()->signWithDigest($message);
+
+        $expectedString = implode(',', [
+            'keyId="pda"',
+            'algorithm="hmac-sha256"',
+            'headers="(request-target) date digest"',
+            'signature="7iFqqryI6I9opV/Zp3eEg6PDY1tKw/3GqioOM7ACHHA="']);
+        $zeroLengthStringDigest =
+          'SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+
+        $this->assertEquals(
+            $expectedString,
+            $message->getHeader('Signature')[0]
+        );
+
+        $this->assertEquals(
+            $zeroLengthStringDigest,
+            $message->getHeader('Digest')[0]
+        );
+
+        $this->assertEquals(
+            'Signature ' . $expectedString,
+            $message->getHeader('Authorization')[0]
+        );
+    }
+
     public function testVerifier()
     {
         $message = $this->noDigestContext->signer()->sign(new Request('GET', '/path?query=123', [


### PR DESCRIPTION
Add ```signWithDigest($message)``` function to include the Digest header with the correct hash and include in the HeaderList before calling ```sign($message)``` to add the signature.
* If an existing digest is present, replace it
* By default use SHA256. Presenting the option to choose an algorithm at runtime would require further work, and be a bigger change to the API.