### PR TITLE
Allow paragonie/random_compat version 9.99.99 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "paragonie/random_compat": "^1.0|^2.0",
+        "paragonie/random_compat": "^1.0|^2.0|9.99.99",
         "psr/http-message": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This library requires paragonie/random_compat versions to be ^1.0|^2.0 except that for people using PHP7 this is not needed. The paragonie guys have provided an [empty version](https://github.com/paragonie/random_compat#version-99999) (9.99.99) to solve exactly this problem. Version 9.99.99 can only be installed in PHP7 but 99designs/http-signatures-php does not allow this version to be installed.

This PR enables 99designs/http-signatures-php to be required in PHP7 systems that already have the paragonie library required and are using version 9.99.99.