### PR TITLE
Explicit build matrix for Travis and PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,41 @@
 language: php
 
-php:
-  - "5.6"
-  - "7.0"
-  - "7.1"
-  - "7.2"
+matrix:
+  include:
+  - php: 5.6
+    env: SYMFONY_VERSION=2
+  - php: 5.6
+    env: SYMFONY_VERSION=3
+  - php: 7.0
+    env: SYMFONY_VERSION=2
+  - php: 7.0
+    env: SYMFONY_VERSION=3
+  - php: 7.1
+    env: SYMFONY_VERSION=2
+  - php: 7.1
+    env: SYMFONY_VERSION=3
+  - php: 7.1
+    env: SYMFONY_VERSION=4
+  - php: 7.2
+    env: SYMFONY_VERSION=2
+  - php: 7.2
+    env: SYMFONY_VERSION=3
+  - php: 7.2
+    env: SYMFONY_VERSION=4
+  - php: 7.3
+    env: SYMFONY_VERSION=2
+  - php: 7.3
+    env: SYMFONY_VERSION=3
+  - php: 7.3
+    env: SYMFONY_VERSION=4
 
 install:
-  - if [ "$SYMFONY_VERSION" != "none" ]; then composer require --no-update symfony/http-foundation \~$SYMFONY_VERSION; fi
+  - if [ ! -z "$SYMFONY_VERSION" ]; then composer require --no-update symfony/http-foundation \~$SYMFONY_VERSION; fi
   - composer install
 
 script:
   - vendor/bin/phpunit
   - vendor/bin/php-cs-fixer fix -v --dry-run
-
-env:
-  - SYMFONY_VERSION: none
-  - SYMFONY_VERSION: 2
-  - SYMFONY_VERSION: 3
-  - SYMFONY_VERSION: 4
-
-matrix:
-  exclude:
-  - php: 5.6
-    env: SYMFONY_VERSION=4
-  - php: 7.0
-    env: SYMFONY_VERSION=4
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ env:
   - SYMFONY_VERSION: ~2
   - SYMFONY_VERSION: ~3
   - SYMFONY_VERSION: ~4
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ php:
   - "7.2"
 
 install:
-  - composer require --no-update symfony/http-foundation $SYMFONY_VERSION; composer install
+  - if [ "$SYMFONY_VERSION" != "none" ]; then composer require --no-update symfony/http-foundation $SYMFONY_VERSION; fi; composer install
 
 script:
   - vendor/bin/phpunit
   - vendor/bin/php-cs-fixer fix -v --dry-run
 
 env:
+  - SYMFONY_VERSION: none
   - SYMFONY_VERSION: ~2
   - SYMFONY_VERSION: ~3
   - SYMFONY_VERSION: ~4

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ php:
   - "7.2"
 
 install:
-  - if [ "$SYMFONY_VERSION" != "none" ]; then composer require --no-update symfony/http-foundation $SYMFONY_VERSION; fi; composer install
+  - if [ "$SYMFONY_VERSION" != "none" ]; then composer require --no-update symfony/http-foundation \~$SYMFONY_VERSION; fi
+  - composer install
 
 script:
   - vendor/bin/phpunit
@@ -15,9 +16,16 @@ script:
 
 env:
   - SYMFONY_VERSION: none
-  - SYMFONY_VERSION: ~2
-  - SYMFONY_VERSION: ~3
-  - SYMFONY_VERSION: ~4
+  - SYMFONY_VERSION: 2
+  - SYMFONY_VERSION: 3
+  - SYMFONY_VERSION: 4
+
+matrix:
+  exclude:
+  - php: 5.6
+    env: SYMFONY_VERSION=4
+  - php: 7.0
+    env: SYMFONY_VERSION=4
 
 cache:
   directories:


### PR DESCRIPTION
Older version of composer used by Travis-CI accepted a dependency failure for PHP<7.1 and Symfony 4, but new composer version explicitly fails to install a dependency, causing those builds to fail.

This PR explicitly declares which builds to conduct in the matrix with known good combinations, and extends to include PHP 7.3.