### PR TITLE
Travis CI config improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,42 @@
 language: php
 
-php:
-  - "5.6"
-  - "7.0"
-  - "7.1"
-  - "7.2"
+matrix:
+  include:
+  - php: 5.6
+    env: SYMFONY_VERSION=2
+  - php: 5.6
+    env: SYMFONY_VERSION=3
+  - php: 7.0
+    env: SYMFONY_VERSION=2
+  - php: 7.0
+    env: SYMFONY_VERSION=3
+  - php: 7.1
+    env: SYMFONY_VERSION=2
+  - php: 7.1
+    env: SYMFONY_VERSION=3
+  - php: 7.1
+    env: SYMFONY_VERSION=4
+  - php: 7.2
+    env: SYMFONY_VERSION=2
+  - php: 7.2
+    env: SYMFONY_VERSION=3
+  - php: 7.2
+    env: SYMFONY_VERSION=4
+  - php: 7.3
+    env: SYMFONY_VERSION=2
+  - php: 7.3
+    env: SYMFONY_VERSION=3
+  - php: 7.3
+    env: SYMFONY_VERSION=4
 
 install:
-  - composer require --no-update symfony/http-foundation $SYMFONY_VERSION; composer install
+  - if [ ! -z "$SYMFONY_VERSION" ]; then composer require --no-update symfony/http-foundation \~$SYMFONY_VERSION; fi
+  - composer install
 
 script:
   - vendor/bin/phpunit
   - vendor/bin/php-cs-fixer fix -v --dry-run
 
-env:
-  - SYMFONY_VERSION: ~2
-  - SYMFONY_VERSION: ~3
-  - SYMFONY_VERSION: ~4
+cache:
+  directories:
+    - $HOME/.composer/cache/files


### PR DESCRIPTION
Older version of composer used by Travis-CI accepted a dependency failure for PHP<7.1 and Symfony 4, but new composer version explicitly fails to install a dependency, causing those builds to fail.

This PR explicitly declares which builds to conduct in the matrix with known good combinations, and extends to include PHP 7.3.