### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - "5.6"
-  - "7.0"
   - "7.1"
   - "7.2"
+  - "7.3"
 
 install:
   - composer require --no-update symfony/http-foundation $SYMFONY_VERSION; composer install

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "paragonie/random_compat": "^1.0|^2.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2",
         "guzzlehttp/psr7": "^1.2",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "~7.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/psr-http-message-bridge": "^1.0.2",
         "zendframework/zend-diactoros": "^1.1"

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -4,12 +4,11 @@ namespace HttpSignatures\tests;
 
 use GuzzleHttp\Psr7\Request;
 use HttpSignatures\Context;
+use PHPUnit\Framework\TestCase;
 
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends TestCase
 {
-    private $context;
-
-    public function setUp()
+    protected function setUp()
     {
         $this->noDigestContext = new Context([
             'keys' => ['pda' => 'secret'],
@@ -185,6 +184,6 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         ]));
 
         // assert it works without errors; correctness of results tested elsewhere.
-        $this->assertTrue(is_bool($this->noDigestContext->verifier()->isValid($message)));
+        $this->assertIsBool($this->noDigestContext->verifier()->isValid($message));
     }
 }

--- a/tests/HeaderListTest.php
+++ b/tests/HeaderListTest.php
@@ -3,8 +3,9 @@
 namespace HttpSignatures\tests;
 
 use HttpSignatures\HeaderList;
+use PHPUnit\Framework\TestCase;
 
-class HeaderListTest extends \PHPUnit_Framework_TestCase
+class HeaderListTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/KeyStoreTest.php
+++ b/tests/KeyStoreTest.php
@@ -3,8 +3,9 @@
 namespace HttpSignatures\tests;
 
 use HttpSignatures\KeyStore;
+use PHPUnit\Framework\TestCase;
 
-class KeyStoreTest extends \PHPUnit_Framework_TestCase
+class KeyStoreTest extends TestCase
 {
     public function testFetchSuccess()
     {

--- a/tests/SignatureParametersParserTest.php
+++ b/tests/SignatureParametersParserTest.php
@@ -3,8 +3,9 @@
 namespace HttpSignatures\tests;
 
 use HttpSignatures\SignatureParametersParser;
+use PHPUnit\Framework\TestCase;
 
-class SignatureParametersParserTest extends \PHPUnit_Framework_TestCase
+class SignatureParametersParserTest extends TestCase
 {
     public function testParseReturnsExpectedAssociativeArray()
     {

--- a/tests/SignatureParametersTest.php
+++ b/tests/SignatureParametersTest.php
@@ -6,8 +6,9 @@ use HttpSignatures\HeaderList;
 use HttpSignatures\HmacAlgorithm;
 use HttpSignatures\Key;
 use HttpSignatures\SignatureParameters;
+use PHPUnit\Framework\TestCase;
 
-class SignatureParametersTest extends \PHPUnit_Framework_TestCase
+class SignatureParametersTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/SigningStringTest.php
+++ b/tests/SigningStringTest.php
@@ -7,8 +7,9 @@ use HttpSignatures\HeaderList;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use HttpSignatures\SigningString;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use PHPUnit\Framework\TestCase;
 
-class SigningStringTest extends \PHPUnit_Framework_TestCase
+class SigningStringTest extends TestCase
 {
     public function testWithoutQueryString()
     {

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -5,8 +5,9 @@ namespace HttpSignatures\tests;
 use GuzzleHttp\Psr7\Request;
 use HttpSignatures\KeyStore;
 use HttpSignatures\Verifier;
+use PHPUnit\Framework\TestCase;
 
-class VerifierTest extends \PHPUnit_Framework_TestCase
+class VerifierTest extends TestCase
 {
     const DATE = 'Fri, 01 Aug 2014 13:44:32 -0700';
     const DATE_DIFFERENT = 'Fri, 01 Aug 2014 13:44:33 -0700';
@@ -21,7 +22,7 @@ class VerifierTest extends \PHPUnit_Framework_TestCase
      */
     private $message;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->setUpVerifier();
         $this->setUpValidMessage();


### PR DESCRIPTION
# Changed log
- Remove `php-5.6` and `php-7.0` versions and let the package require `php-7.1` version at least.
The `php-7.1` version is the minimum stable version.
- Upgrade PHPUnit version `7.0` for `php-7.1`  version.
- Using the namespace PHPUnit for latest stable PHPUnit version.