### PR TITLE
Remove random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     },
     "require": {
         "php": ">=7.1",
-        "paragonie/random_compat": "^1.0|^2.0|9.99.99",
         "psr/http-message": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
# Changed log
- According to the [official PHP doc](https://www.php.net/manual/en/function.random-bytes.php), the `random_*`  functions are available in `php-7.x` versions.

Remove this random compatibility dependency because native functions are available in `php-7.x`.